### PR TITLE
Fix demo link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ quasar ext remove @quasar/qscroller
 Can be found [here](https://github.com/quasarframework/app-extension-qscroller/tree/master/demo).
 
 # Demo
-Demo [here](https://quasarframework.github.io/app-extension-qscroller/#/demo)
+Demo [here](https://quasarframework.github.io/app-extension-qscroller/demo)
 
 # Documentation
 Can be found [here](https://quasarframework.github.io/app-extension-qscroller/).


### PR DESCRIPTION
The description was fixed after [this comment](https://github.com/quasarframework/app-extension-qpdfviewer/issues/1#issuecomment-503005403), but I noticed that the link in README is still broken. This PR aims to fix it.